### PR TITLE
refs #7 コマンドラインオプションで type オプションが指定された場合の処理を追加した．

### DIFF
--- a/src/main/java/com/github/finder/Finder.java
+++ b/src/main/java/com/github/finder/Finder.java
@@ -24,6 +24,9 @@ public class Finder {
         if(args.getName() != null){
             flag &= checkTargetName(file, args.getName());
         }
+	if(args.getType() != null){
+            flag &= checkTargetType(file, args.getType());
+        }
         return flag;
     }
 
@@ -36,5 +39,24 @@ public class Finder {
                 traverse(list, file);
             }
         }
+    }
+
+    private boolean checkTargetName(File file, String pattern){
+        String name = file.getName();
+        return name.indexOf(pattern) >= 0;
+    }
+
+    private boolean checkTargetType(File file, String type){
+        type = type.toLowerCase();
+        if(type.equals("d") || type.equals("directory")){
+            return file.isDirectory();
+        }
+        else if(type.equals("f") || type.equals("file")){
+            return file.isFile();
+        }
+        else if(type.equals("h") || type.equals("hidden")){
+            return file.isHidden();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
FinderクラスのisTargetメソッドに，typeオプションが指定された場合の処理を追加した．
typeがdもしくはdirectoryの場合はディレクトリであったときisTargetメソッドはtrueを返し，type が
hもしくはhiddenの場合は隠しファイルであったときisTargetメソッドはtrueを返し，その他の場合はfalseを返すcheckTarg
etTypeを追加した．
name-optionブランチで追加し忘れたcheckTargetNameメソッドを追加した．
